### PR TITLE
Bump requests from 2.32.3 to 2.32.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "xmltodict>=0.14.2",
-    "requests>=2.32.3",
+    "requests>=2.32.4",
     "urllib3>=2.5.0",
     "pytz>=2024.2",
     "iupdatable>=0.3.1",


### PR DESCRIPTION
## Security Fix: requests 2.32.3 -> 2.32.4
Bumps requests from 2.32.3 to 2.32.4. Resolves Dependabot PR #2.
Note: urllib3 is already at >=2.5.0 on master so Dependabot PR #3 is also resolved.
Applied by Claude Code automated dependency update workflow.