### PR TITLE
chore: declare venv for pyright in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,7 @@ dev = [
 
 # ... other project metadata fields as specified in:
 #     https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"


### PR DESCRIPTION
## What

Adds a `[tool.pyright]` block to `pyproject.toml`:

```toml
[tool.pyright]
venvPath = "."
venv = ".venv"
```

## Why

pyright resolves imports against the first `python` found on `PATH` — it does **not** auto-detect `./.venv` on its own. Without an explicit `venvPath`/`venv` declaration, it silently falls back to the system interpreter and reports every first-party and third-party import as unresolved, which then cascades into a wave of false-positive attribute errors on otherwise-correct code.

Declaring the venv location here means `uv sync --group dev` alone is enough to get clean pyright output — no manual venv activation required. This is tool-agnostic: it helps pyright in any editor, in any agent/CLI integration, and in CI, with no editor-specific config committed to the repo.

Measured on `asset-service/asset/views.py` as a representative case: 17 errors / 19 unresolved imports against the system python, 4 errors / 0 unresolved imports with the venv correctly resolved.

This repo does not currently run pyright in CI, so this change has no effect on the build — it only improves local/agent tooling accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)