### PR TITLE
Clean up docs, license headers, and docstrings

### DIFF
--- a/oBIX/client/client.py
+++ b/oBIX/client/client.py
@@ -35,18 +35,7 @@ class Client:
         enable_proxy=False,
         proxy_dict=None,
     ):
-        """
-        init a oBIX client
-        Args:
-            host: PC IP, E.g: 127.0.0.1
-            user_name: user name
-            password: password
-            port: [Optional] the ip port to access
-            https: [Optional] whether enable `https`, default is True
-            enable_proxy: [Optional] whether to use a proxy server, default is False
-            proxy_dict: [Optional] if `enable_proxy` is enabled, this parameter is required.
-                E.g: proxy_dict = {'http': 'http://127.0.0.1:8888', "https": "https://127.0.0.1:8888"}
-        """
+        """If enable_proxy is True, proxy_dict must be like {'http': ..., 'https': ...}."""
         self.__host = str(host).strip()
         self.__user_name = str(user_name).strip()
         self.__password = str(password).strip()
@@ -81,7 +70,6 @@ class Client:
         Logger.instance().config(log_file_full_path="oBIX.log")
 
     def __del__(self):
-        # clear jobs and shutdown scheduler
         if self.__scheduler is not None:
             self.__scheduler.remove_all_jobs()
             if self.__scheduler.running:
@@ -131,8 +119,6 @@ class Client:
             Logger.instance().error("{0} Failed: {1}".format(context, error_msg))
             return error_msg
         return None
-
-    # Serialisation helpers
 
     def __serialize_one_data(self, value, data_type: DataType, parameter=None):
         try:
@@ -214,7 +200,6 @@ class Client:
             response = self.__do_get(url)
             if response.status_code == 200:
                 xml_root = xmlElement.fromstring(response.text)
-                # check err
                 if "err" in xml_root.tag and "display" in xml_root.attrib:
                     Logger.instance().error(
                         "[{} read_point Error]: {}".format(
@@ -268,13 +253,7 @@ class Client:
     def override_point(
         self, point_path: str, value, data_type: DataType, time_delta: timedelta = None
     ):
-        """Override a point value with an optional duration.
-
-        Merges the previous ``override_point`` (with value) and
-        ``override_point_command`` (command-only) behaviours into a single
-        method.  Pass ``value=None`` and omit ``data_type`` to issue a
-        command-only override (equivalent to the old override_point_command).
-        """
+        """Override a point value with an optional duration; pass value=None to issue a command-only override."""
         try:
             url = self.__get_url(point_path, "override")
             post_data = dict()
@@ -621,54 +600,17 @@ class Client:
             return None
 
     def add_watch_points(self, point_path_list: [str], watch_id=""):
-        """
-        Add new objects to watch
-        Args:
-            point_path_list: a list of URIs
-                            Examples
-                                ["/config/examples/BooleanWritable/", "/config/examples/NumericWritable/"]
-            watch_id: the watch identity, default is ""
-                        if watch_id is empty string, it will use a default watch (if not exist, will create first)
-                      Examples
-                        "watch84"
-        Returns:
-
-        """
+        """Add points to a watch; an empty watch_id uses (or creates) the default watch."""
         return self.__operate_watch_points("add", point_path_list, watch_id)
 
     def remove_watch_points(self, point_path_list: [str], watch_id=""):
-        """
-        Remove objects from watch
-        Args:
-            point_path_list: a list of URIs
-                            Examples
-                                ["/config/examples/BooleanWritable/", "/config/examples/NumericWritable/"]
-            watch_id: the watch identity, default is ""
-                        if watch_id is empty string, it will use a default watch (if not exist, will create first)
-                      Examples
-                        "watch84"
-        Returns:
-
-        """
+        """Remove points from a watch; an empty watch_id uses (or creates) the default watch."""
         return self.__operate_watch_points("remove", point_path_list, watch_id)
 
     def __operate_watch_points(
         self, operation: str, point_path_list: [str], watch_id=""
     ):
-        """
-        Remove objects from watch
-        Args:
-            operation: "add" or "remove" or "pollChanges"
-            point_path_list: a list of URIs
-                            Examples
-                                ["/config/examples/BooleanWritable/", "/config/examples/NumericWritable/"]
-            watch_id: the watch identity, default is ""
-                        if watch_id is empty string, it will use a default watch (if not exist, will create first)
-                      Examples
-                        "watch84"
-        Returns:
-
-        """
+        """Dispatch a watch operation (add/remove/pollChanges/pollRefresh); an empty watch_id uses (or creates) the default watch."""
         try:
             if watch_id == "":
                 if len(self.__watch_id_list) == 0:
@@ -868,19 +810,7 @@ class Client:
     def export_points(
         self, folder_path="", export_file_name="all_points.json", export_type=0
     ):
-        """
-        Export the information of all points in the specified directory
-        Args:
-            folder_path: The directory you want to export. E.g: "/config/xxx/"
-                All data points will be exported by default.
-            export_file_name: The file path to save the result, default is "all_points.json"
-            export_type: The output style, the default is 0
-                0: JSON format, Nested way and preserve directory structure
-                1: JSON format, pure point list with properties, ignoring directory structure
-                2: string list, pure point url list
-        Returns: According to the parameter `export_type` setting, return different forms points information
-        If there is no point in the current directory or an exception occurs, it returns None
-        """
+        """Export points under folder_path to a file; export_type selects nested JSON (0), flat JSON (1), or a URL list (2)."""
         try:
             url = self.__host_url + "/obix/"
             if folder_path:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,8 +7,6 @@ from unittest.mock import patch, MagicMock, PropertyMock
 from oBIX.common.data_type import DataType
 
 
-# Helpers / fixtures
-
 def _make_response(status_code: int, text: str) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status_code
@@ -54,8 +52,6 @@ def client():
         yield c
 
 
-# __get_url
-
 class TestGetUrl:
     def test_basic_path(self, client):
         url = client._Client__get_url("/config/test/")
@@ -73,8 +69,6 @@ class TestGetUrl:
         url = client._Client__get_url("/config/test/", "set")
         assert url == "https://127.0.0.1/obix/config/test/set"
 
-
-# read_point
 
 class TestReadPoint:
     def test_returns_point_on_200(self, client):
@@ -99,8 +93,6 @@ class TestReadPoint:
         assert result is None
 
 
-# read_point_value / read_point_slot
-
 class TestReadPointValue:
     def test_returns_float_for_real_point(self, client):
         with patch.object(client, "_Client__do_get", return_value=_make_response(200, REAL_POINT_XML)):
@@ -112,8 +104,6 @@ class TestReadPointValue:
             value = client.read_point_value("/bad/")
         assert value is None
 
-
-# __parse_xml_response (static helper)
 
 class TestParseXmlResponse:
     def test_returns_dict_and_first_key(self):
@@ -127,8 +117,6 @@ class TestParseXmlResponse:
         root_dict, first_key = Client._Client__parse_xml_response(ERR_XML)
         assert "err" in first_key
 
-
-# __check_xml_error (static helper)
 
 class TestCheckXmlError:
     def test_returns_none_for_ok_response(self):
@@ -145,8 +133,6 @@ class TestCheckXmlError:
             result = Client._Client__check_xml_error(root_dict, first_key, "Test")
         assert result == "No such object: /bad/path/"
 
-
-# override_point
 
 class TestOverridePoint:
     def test_returns_ok_on_success(self, client):
@@ -181,8 +167,6 @@ class TestOverridePoint:
         assert "val=" not in post_data or "PT0S" in post_data
 
 
-# override_point_command
-
 class TestOverridePointCommand:
     def test_returns_ok_on_success(self, client):
         with patch.object(client, "_Client__do_post", return_value=_make_response(200, OK_XML)):
@@ -195,8 +179,6 @@ class TestOverridePointCommand:
         assert result is False
 
 
-# set_point_value / set_point_auto
-
 class TestSetPointValue:
     def test_set_point_value_ok(self, client):
         with patch.object(client, "_Client__do_post", return_value=_make_response(200, OK_XML)):
@@ -207,9 +189,6 @@ class TestSetPointValue:
         with patch.object(client, "_Client__do_post", return_value=_make_response(200, OK_XML)):
             result = client.set_point_auto("/config/station/p/", DataType.real)
         assert result == "OK"
-
-
-# create_new_watch
 
 
 class TestCreateNewWatch:
@@ -234,8 +213,6 @@ class TestCreateNewWatch:
             result = client.create_new_watch()
         assert result is None
 
-
-# start_watch / stop_watch
 
 class TestStartStopWatch:
     def test_start_watch_calls_start_when_not_running(self, client):
@@ -274,8 +251,6 @@ class TestInstanceIsolation:
         c1._Client__watch_id_list.append("watch_a")
         assert "watch_a" not in c2._Client__watch_id_list
 
-
-# __serialize_data
 
 class TestSerializeData:
     def test_real_serialisation(self, client):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -104,11 +104,7 @@ class TestParsePoint:
     """Util.parse_point: dict -> Point."""
 
     def _make_real_point_dict(self):
-        """Return a minimal real-valued point dict as produced by xmltodict.
-
-        The @is attribute mirrors what oBIX servers actually return: a
-        space-separated list that includes 'obix:Point'.
-        """
+        """Return a minimal real-valued point dict shaped like an oBIX xmltodict payload (@is includes 'obix:Point')."""
         slots = [
             {"@name": "out", "@display": "42.0", "@val": "42.0"},
             {"@name": "in1", "@display": "{null}", "@val": "null"},


### PR DESCRIPTION
## Summary
- Docs audit: only `README.md` exists in this repo (root-level, always kept) — no PRDs/product docs/outdated docs to move to product/product.
- License headers: no verbose multi-line license header blocks exist in any source file — nothing to compress.
- Docstrings: collapsed every multi-line docstring in `oBIX/client/client.py` (`__init__`, `override_point`, `add_watch_points`, `remove_watch_points`, `__operate_watch_points`, `export_points`) to a single line each, per the one-line-comment convention. In the process, corrected a stale docstring on `__operate_watch_points` that claimed it only "removes" objects, when it actually dispatches add/remove/pollChanges/pollRefresh.
- Removed comments that only restated the code immediately below them (e.g. `# check err`, `# clear jobs and shutdown scheduler`, per-test-class section labels that just repeated the class name).
- Collapsed one multi-line docstring in `tests/test_util.py` to a single line.

## Test plan
- [x] `python3 -m py_compile` on all touched/source files
- [x] `uv run pytest -q` — 91 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)